### PR TITLE
Load jsDeliver JSON over HTTPS

### DIFF
--- a/modules/jsdelivrAPI.js
+++ b/modules/jsdelivrAPI.js
@@ -4,7 +4,7 @@
 define(function (require, exports, module) {
   'use strict';
   
-  var URL = 'http://api.jsdelivr.com/v1/{cdn}/libraries?fields=name,mainfile,versions';
+  var URL = 'https://api.jsdelivr.com/v1/{cdn}/libraries?fields=name,mainfile,versions';
   
   /**
    * Downloads the libraries hosted by the specified CDN.


### PR DESCRIPTION
jsDeliver supports HTTPS, see http://www.jsdelivr.com/faq.php.  We're using your extension in our browser fork of Brackets, which runs over HTTPS, and things currently fail due to this cross-origin request (https://github.com/humphd/brackets/issues/308).  This fixes it.